### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=FourThreeThree
+version=0.1.0
+author=Jonathan Heathcote
+maintainer=Jonathan Heathcote
+sentence=A simple (and excruciatingly primitive) 433 MHz radio library.
+paragraph=
+category=Communication
+url=https://github.com/mossblaser/FourThreeThree
+architectures=*
+includes=FourThreeThree.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata